### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM elixir:1.10.4-alpine
+
+ENV APP_HOME /app
+RUN mkdir -p $APP_HOME
+
+COPY config/ $APP_HOME/config
+COPY lib/ $APP_HOME/lib
+COPY priv/ $APP_HOME/priv
+COPY *.exs mix.lock run_server.sh $APP_HOME/
+
+WORKDIR ${APP_HOME}
+
+RUN mix local.hex --force && mix local.rebar --force && mix deps.get && mix deps.compile
+
+CMD ["./run_server.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  phoenix:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./Mnesia.nonode@nohost:/app/Mnesia.nonode@nohost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       - "4000:4000"
     volumes:
       - ./Mnesia.nonode@nohost:/app/Mnesia.nonode@nohost
+      - ./priv:/app/priv

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+elixir -S mix run -e "Omnixent.Mnesia.persist()"
+mix phx.server


### PR DESCRIPTION
This PR adds Docker to omnixent-server. The dockerfile copies all the required folders, installs all the dependencies and then runs a script to to create the Mnesia Schema on disk (`Omnixent.Mnesia.persist()`) and boot up the server.

I opened it in draft since I'm not an Elixir (and Phoenix) expert, I think it will need some rework!